### PR TITLE
add quickquit

### DIFF
--- a/docs/mod-lists/general-mod-list.md
+++ b/docs/mod-lists/general-mod-list.md
@@ -11,7 +11,7 @@ Select your Minecraft version below to view compatible mods.
 
     ## 1.8.9 Mods
 
-    ### Optifine
+    ### OptiFine
     Adds many visual fixes and improvements to Minecraft, provides support for shader packs and advanced texture pack features
     
     - Download: https://optifine.net/downloads
@@ -79,11 +79,17 @@ Select your Minecraft version below to view compatible mods.
     - Download: https://github.com/Polyfrost/CrashPatch/releases/
     - Support: https://polyfrost.cc/discord
 
+    ### QuickQuit
+    Let's you close Minecraft during the launch loading screen
+
+    - Download: https://modrinth.com/mod/quickquit/versions
+    - Support: https://discord.gg/rejfv9kFJj
+
 === "1.20.x"
 
     ## 1.20.x Mods
 
-    ### Optifine
+    ### OptiFine
     Adds many visual fixes and improvements to Minecraft, provides support for shader packs and advanced texture pack features
 
     - Download: https://optifine.net/downloads


### PR DESCRIPTION
QuickQuit is a mod I made that backports newer versions of forge's ability to close the game during the loading screen when launching the game. With forge being very slow with launch times I figured it was a nice enough change to add to this list, even though it is a very small mod. I'm not sure how mods are ordered here so I just threw it at the bottom.

I also just quickly edited Optifine -> OptiFine as that's how the OptiFine website capitalizes itself. (speaking of, why is OptiFine even listed in the 1.20 category it doesn't work on fabric natively, yet the skyblock 1.20 mods are all fabric)