### PR TITLE
Change Skyblocker download link to use Modrinth

### DIFF
--- a/docs/mod-lists/skyblock-mod-list.md
+++ b/docs/mod-lists/skyblock-mod-list.md
@@ -130,5 +130,5 @@ Select your Minecraft version below to view compatible mods.
     - Support: https://discord.gg/WnJwrNZQSn
     
     ### Skyblocker
-    - Download: https://github.com/SkyblockerMod/Skyblocker/releases
+    - Download: https://modrinth.com/mod/skyblocker-liap/versions
     - Support: https://discord.com/invite/aNNJHQykck


### PR DESCRIPTION
Changes the download link for the Skyblocker mod to use Modrinth as we occasionally we release beta versions for new Minecraft versions or interim fixes before a full release that only get published to Modrinth, it's also our main/preferred distribution platform so this will more accurately reflect that.